### PR TITLE
Updates for discover (mathomp4)

### DIFF
--- a/config/discover.yaml
+++ b/config/discover.yaml
@@ -1,13 +1,14 @@
 machine:
   name: discover
-  cores_per_node: 28
+  cores_per_node: 120
   git_https: True
   scheduler:
     type: slurm
-    account: s2326
-    #account: j1100
+    account: s1873
     queue: allnccs
     partition: compute
+    constraint: mil
+  module_path: /discover/swdev/gmao_SIteam/modulefiles-SLES15
 
 test:
   esmf_branch: [release/8.7.0]
@@ -15,42 +16,61 @@ test:
 
 matrix:
   intel:
-     versions:
-       19.1.3:
-         compiler: comp/intel/19.1.3.304
-         netcdf: netcdf4/4.7.4
-         extra_module: cmake
-         mpi:
-           intelmpi:
-             module: mpi/impi/19.1.3.304
+    test_time: "2:00:00"
+    versions:
+      2021.6.0:
+        compiler: comp/intel/2021.6.0
+        #netcdf: netcdf4/4.9.2-ser
+        netcdf: None
+        extra_module: cmake/3.30.3 comp/gcc/11.6.0
+        mpi:
+          intelmpi:
+            module: mpi/impi/2021.13
+            mpi_env_vars:
+              - I_MPI_CXX=icpc
+              - I_MPI_CC=icc
+        extra_env_vars:
+          - I_MPI_OFI_PROVIDER=psm3
+          - I_MPI_FABRICS=shm:ofi
+      2021.13.0:
+        compiler: comp/intel/2024.2.0
+        #netcdf: netcdf4/4.9.2-ser
+        netcdf: None
+        extra_module: cmake/3.30.3 comp/gcc/12.3.0
+        mpi:
+          intelmpi:
+            module: mpi/impi/2021.13
+            mpi_env_vars:
+              - I_MPI_CXX=icpx
+              - I_MPI_CC=icx
+              - I_MPI_F90=ifort
+        extra_env_vars:
+          - I_MPI_OFI_PROVIDER=psm3
+          - I_MPI_FABRICS=shm:ofi
+      2024.2.0:
+        compiler: comp/intel/2024.2.0
+        #netcdf: netcdf4/4.9.2-ser
+        netcdf: None
+        extra_module: cmake/3.30.3 comp/gcc/12.3.0
+        mpi:
+          intelmpi:
+            module: mpi/impi/2021.13
+            mpi_env_vars:
+              - I_MPI_CXX=icpx
+              - I_MPI_CC=icx
+              - I_MPI_F90=ifx
+        extra_env_vars:
+          - I_MPI_OFI_PROVIDER=psm3
+          - I_MPI_FABRICS=shm:ofi
   gfortran:
-     versions:
-       8.3.0:
-         compiler: comp/gcc/8.3.0
-         netcdf: None
-         extra_module: cmake
-         mpi:
-             intelmpi:
-               module: mpi/impi/19.1.3.304
-             mpiuni:
-               module: None
-       10.1.0:
-         compiler: comp/gcc/10.1.0
-         netcdf: None
-         extra_module: cmake
-         mpi:
-             intelmpi:
-               module:  mpi/impi/19.1.3.304
-  pgi:
-     build_time: "2:00:00"
-     test_time:  "2:00:00"
-     versions:
-       20.4:
-         compiler: comp/pgi/20.4
-         netcdf: None
-         extra_module: cmake
-         mpi:
-  #           intelmpi:
-  #             module: mpi/impi/20.0.0.166
-             mpiuni:
-               module: None
+    test_time: "2:00:00"
+    versions:
+      13.2.0:
+        compiler: comp/gcc/13.2.0
+        netcdf: None
+        extra_module: cmake/3.30.3
+        mpi:
+          openmpi:
+            module: mpi/openmpi/4.1.6/gcc-13.2.0
+          mpiuni:
+            module: none

--- a/runscripts/run_esmf_tests_discover.sh
+++ b/runscripts/run_esmf_tests_discover.sh
@@ -1,8 +1,18 @@
 #!/bin/bash -l
 
-module load python/GEOSpyD/Ana2019.10_py3.7 git/2.30.0
-cd /discover/nobackup/projects/sbu/mpotts/esmf-test/esmf-test-scripts
+ESMF_TEST_ROOT=/discover/nobackup/projects/gmao/SIteam/ESMF_Testing
+
+# These are for SLES12
+#module use /discover/swdev/gmao_SIteam/modulefiles-SLES12
+#module load python/GEOSpyD/Min24.4.0-0_py3.11 git/2.40.1
+# These are for SLES15
+module use /discover/swdev/gmao_SIteam/modulefiles-SLES15
+module load python/GEOSpyD/24.3.0-0/3.11 git/2.45.0
+
+cd $ESMF_TEST_ROOT/esmf-test-scripts
+
 git remote update
 git pull -X theirs origin --no-edit
-/discover/nobackup/projects/sbu/mpotts/esmf-test/esmf-test-scripts/python_scripts/test_esmf.py -r /discover/nobackup/projects/sbu/mpotts/esmf-test -m discover 
+
+$ESMF_TEST_ROOT/esmf-test-scripts/python_scripts/test_esmf.py -r $ESMF_TEST_ROOT -m discover 
 


### PR DESCRIPTION
As I don't seem to have write access to the mother repo (I can't push a branch), I beseech @theurich if he could pull in these changes for discover as I've been asked to take over running them by @oehmke 

At the moment, the tests are all now on the SLES15/Milan nodes at NCCS and I've updated the compilers to sort of match what's currently used by GMAO.

Well, sort of. These are all building without netcdf because I need to figure out how to get that as the only netcdf module file on discover was built by system GCC which means maaaaybe the gfortran 13 tests could use the `netcdf.mod` file, but Intel will not.

Also, I think there still might be issues with my setup as for some reason, not all the tests that ran last night were uploaded to artifacts.