### PR TITLE
Fix gcc module for discover intel 2021.6

### DIFF
--- a/config/discover.yaml
+++ b/config/discover.yaml
@@ -22,7 +22,7 @@ matrix:
         compiler: comp/intel/2021.6.0
         #netcdf: netcdf4/4.9.2-ser
         netcdf: None
-        extra_module: cmake/3.30.3 comp/gcc/11.6.0
+        extra_module: cmake/3.30.3 comp/gcc/11.4.0
         mpi:
           intelmpi:
             module: mpi/impi/2021.13


### PR DESCRIPTION
Found a bug in the discover config. Tried to load a non-existent module. That doesn't help.