### PR TITLE
discover: add intel mpiuni test

### DIFF
--- a/config/discover.yaml
+++ b/config/discover.yaml
@@ -53,6 +53,12 @@ matrix:
         netcdf: None
         extra_module: cmake/3.30.3 comp/gcc/12.3.0
         mpi:
+          mpiuni:
+            module: None
+            mpi_env_vars:
+              - ESMF_CXX=icpx
+              - ESMF_CC=icx
+              - ESMF_F90=ifx
           intelmpi:
             module: mpi/impi/2021.13
             mpi_env_vars:


### PR DESCRIPTION
Per request of @oehmke I've added an `mpiuni` test for one of the Intel (`ifx` 2024.2).

I shamelessly stole this from the hera template of @theurich 😄 