### PR TITLE
Add netcdf4 python package to conda environments

### DIFF
--- a/config/cheyenne.yaml
+++ b/config/cheyenne.yaml
@@ -45,7 +45,7 @@ matrix:
             module: openmpi/4.0.5
           mpt:
             module: mpt/2.23
-        extra_env_vars:
+        esmpy_env_vars:
           - ESMPY_DATA_DIR="/glade/work/theurich/esmf-test-data/grids"
         esmpy:
           python: python/3.7.9
@@ -56,7 +56,7 @@ matrix:
         mpi:
           mpt:
             module: mpt/2.25
-        extra_env_vars:
+        esmpy_env_vars:
           - ESMPY_DATA_DIR="/glade/work/theurich/esmf-test-data/grids"
         esmpy:
           python: python/3.7.9
@@ -78,7 +78,7 @@ matrix:
             module: openmpi/3.1.4
           intelmpi:
             module: impi/2018.4.274
-        extra_env_vars:
+        esmpy_env_vars:
           - ESMPY_DATA_DIR="/glade/work/theurich/esmf-test-data/grids"
         esmpy:
           python: python/3.7.9

--- a/config/derecho.yaml
+++ b/config/derecho.yaml
@@ -45,7 +45,7 @@ matrix:
               - ESMF_PIO=external
               - ESMF_PIO_INCLUDE="$PIO/include"
               - ESMF_PIO_LIBPATH="$PIO/lib"
-        extra_env_vars:
+        esmpy_env_vars:
           - ESMPY_DATA_DIR="/glade/derecho/scratch/sacks/esmf-testing/esmf-test-data/grids"
         esmpy:
           # This python version corresponds to the suffix in environment-python3.8-numpy1.19.yml
@@ -68,8 +68,9 @@ matrix:
             mpi_env_vars:
               - ESMF_MPIRUN=mpiexec
         extra_env_vars:
-          - ESMPY_DATA_DIR="/glade/derecho/scratch/sacks/esmf-testing/esmf-test-data/grids"
           - ESMF_TEST_NUOPC_JULIA=ON
+        esmpy_env_vars:
+          - ESMPY_DATA_DIR="/glade/derecho/scratch/sacks/esmf-testing/esmf-test-data/grids"
         esmpy:
           # This python version corresponds to the suffix in environment-python3.13-numpy2.1.yml
           # This gives test coverage of the latest supported python and numpy versions

--- a/config/green.yaml
+++ b/config/green.yaml
@@ -28,6 +28,12 @@ matrix:
           - ESMF_TEST_NUOPC_JULIA=ON
         esmpy_env_vars:
           - ESMPY_DATA_DIR="/Users/sacks/projects/scratch/esmf-testing/esmf-test-data/grids"
+          # This is needed so that we use the correct hdf5 library (the system-level
+          # library, as opposed to the hdf5 library in the conda environment when the
+          # netCDF4 python package is included in the conda environment). Note that
+          # DYLD_LIBRARY_PATH begins unset on green, so we simply set the path rather than
+          # appending with something like "${DYLD_LIBRARY_PATH}:/opt/homebrew/lib".
+          - DYLD_LIBRARY_PATH="/opt/homebrew/lib"
         esmpy:
           # This python version corresponds to the suffix in environment-python3.11-numpy1.26.yml
           python: python3.11-numpy1.26

--- a/config/green.yaml
+++ b/config/green.yaml
@@ -25,8 +25,9 @@ matrix:
             bopt: [g]
         extra_env_vars:
           - ESMF_TESTPERFORMANCE=OFF
-          - ESMPY_DATA_DIR="/Users/sacks/projects/scratch/esmf-testing/esmf-test-data/grids"
           - ESMF_TEST_NUOPC_JULIA=ON
+        esmpy_env_vars:
+          - ESMPY_DATA_DIR="/Users/sacks/projects/scratch/esmf-testing/esmf-test-data/grids"
         esmpy:
           # This python version corresponds to the suffix in environment-python3.11-numpy1.26.yml
           python: python3.11-numpy1.26

--- a/config/hearhear.yaml
+++ b/config/hearhear.yaml
@@ -35,7 +35,7 @@ matrix:
           mpiuni:
             module: None
             mpi_netcdf: netcdf-c-nompi/4.9.2 netcdf-fortran-nompi/4.6.1
-        extra_env_vars:
+        esmpy_env_vars:
           - ESMPY_DATA_DIR="/Users/sacks/scratch/esmf-testing/esmf-test-data/grids"
         esmpy:
           # This python version corresponds to the suffix in environment-python3.11-numpy1.26.yml
@@ -56,7 +56,7 @@ matrix:
           mpiuni:
             module: None
             mpi_netcdf: netcdf-c-nompi/4.9.2 netcdf-fortran-nompi/4.6.1
-        extra_env_vars:
+        esmpy_env_vars:
           - ESMPY_DATA_DIR="/Users/sacks/scratch/esmf-testing/esmf-test-data/grids"
         esmpy:
           # This python version corresponds to the suffix in environment-python3.11-numpy1.26.yml

--- a/py_env_creation/environment-python3.11-numpy1.26.yml
+++ b/py_env_creation/environment-python3.11-numpy1.26.yml
@@ -1,5 +1,6 @@
 python=3.11.11
 numpy=1.26.4
+netcdf4=1.7.2
 pytest=8.3.4
 pytest-json-report=1.5.0
 pyyaml=6.0.2

--- a/py_env_creation/environment-python3.13-numpy2.1.yml
+++ b/py_env_creation/environment-python3.13-numpy2.1.yml
@@ -1,5 +1,6 @@
 python=3.13.1
 numpy=2.1.3
+netcdf4=1.7.2
 pytest=8.3.4
 pytest-json-report=1.5.0
 pyyaml=6.0.2

--- a/py_env_creation/environment-python3.8-numpy1.19.yml
+++ b/py_env_creation/environment-python3.8-numpy1.19.yml
@@ -1,5 +1,6 @@
 python=3.8.20
 numpy=1.19.5
+netcdf4=1.6.0
 pytest=8.3.4
 pytest-json-report=1.5.0
 pyyaml=6.0.2

--- a/python_scripts/README.md
+++ b/python_scripts/README.md
@@ -71,7 +71,7 @@ A few pieces need to be added to enable ESMPy testing on a machine:
 
 1. `head_node_name` needs to be specified under the machine block (this is needed because the ESMPy testing ssh's to the head node to do the ESMPy installation).
 
-2. Under any combo where ESMPy testing will be run, add `ESMPY_DATA_DIR` under the `extra_env_vars` section, pointing to the directory set up above.
+2. Under any combo where ESMPy testing will be run, add `ESMPY_DATA_DIR` under the `esmpy_env_vars` section, pointing to the directory set up above.
 
 3. Under any combo where ESMPy testing will be run, add an `esmpy` section with a single element specifying the python version to be used. This needs to correspond to one of the supported versions in a yml file in the `py_env_creation` directory (e.g., for `environment-python3.11.yml`, specify `python: python3.11`).
 
@@ -105,7 +105,7 @@ index 77ccf68..048346d 100644
                - ESMF_PIO=external
                - ESMF_PIO_INCLUDE="$PIO/include"
                - ESMF_PIO_LIBPATH="$PIO/lib"
-+        extra_env_vars:
++        esmpy_env_vars:
 +          - ESMPY_DATA_DIR="/glade/work/theurich/esmf-test-data/grids"
 +        esmpy:
 +          # This python version corresponds to the suffix in environment-python3.11.yml
@@ -126,7 +126,7 @@ index 77ccf68..048346d 100644
              module: cray-mpich/8.1.27
              mpi_env_vars:
                - ESMF_MPIRUN=mpiexec
-+        extra_env_vars:
++        esmpy_env_vars:
 +          - ESMPY_DATA_DIR="/glade/work/theurich/esmf-test-data/grids"
 +        esmpy:
 +          # This python version corresponds to the suffix in environment-python3.11.yml

--- a/python_scripts/case.py
+++ b/python_scripts/case.py
@@ -129,6 +129,15 @@ class Case:
         """
         return self.machine.scheduler.check_queue(self.test_job_num)
 
+    @staticmethod
+    def _write_env_vars(env_vars, out):
+        """
+        Write export commands for all environment variables in the given list
+        """
+        if env_vars is not None:
+            for var in env_vars:
+                out.write(f"export {var}\n")
+
     def _create_modules_fragment(self):
         """
         Create the module load section used at the top of both the build and test scripts.
@@ -154,15 +163,11 @@ class Case:
                 out.write(f"module load {e.netcdf_fortran_module}\n")
 
             out.write("\nset -x\n")
-            if e.extra_env_vars is not None:
-                for _var in e.extra_env_vars:
-                    out.write(f"export {_var}\n")
+            self._write_env_vars(e.extra_env_vars, out)
             if e.extra_commands is not None:
                 for _cmd in e.extra_commands:
                     out.write(f"{_cmd}\n")
-            if e.mpi_env_vars is not None:
-                for _var in e.mpi_env_vars:
-                    out.write(f"export {_var}\n")
+            self._write_env_vars(e.mpi_env_vars, out)
 
             out.write(f"export ESMF_DIR={self.esmf_clone_path}\n")
             out.write(f"export ESMF_COMPILER={e.compiler}\n")
@@ -258,6 +263,7 @@ class Case:
         with StringIO() as out:
             out.write(f"#!{self.machine.bash} -l\n")
             out.write(self._create_modules_fragment())
+            self._write_env_vars(self.combo.esmpy_env_vars, out)
             out.write(f"cd {self.esmf_clone_path}\n")
             out.write(f"export ESMFMKFILE=`find $PWD/DEFAULTINSTALLDIR -iname esmf.mk`\n")
 

--- a/python_scripts/combination.py
+++ b/python_scripts/combination.py
@@ -24,6 +24,7 @@ class Combination:
         self.extra_commands = None
         self.extra_env_vars = None
         self.module_path = None
+        self.esmpy_env_vars = None
         self.python_conda_env = None
 
     def label(self):

--- a/python_scripts/matrix.py
+++ b/python_scripts/matrix.py
@@ -63,6 +63,8 @@ class Matrix:
                             combo.extra_commands = versions[compiler_version]["extra_commands"]
                         if "extra_env_vars" in versions[compiler_version]:
                             combo.extra_env_vars = versions[compiler_version]["extra_env_vars"]
+                        if "esmpy_env_vars" in versions[compiler_version]:
+                            combo.esmpy_env_vars = versions[compiler_version]["esmpy_env_vars"]
                         if "esmpy" in versions[compiler_version]:
                             combo.python_conda_env = versions[compiler_version]["esmpy"]["python"]
 


### PR DESCRIPTION
This adds the netcdf4 python package to the conda environments we use for nightly testing of ESMPy. This is needed to enable a few tests in ESMPy. I had originally attempted this but backed it out because of the problems noted in #102 . But, in this PR, I have added an additional setting on green that seems to solve this issue (and it seems like this might not actually be an issue on derecho, but I'm checking that now.)

Resolves #102 